### PR TITLE
Support signal trigger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mruby/
+a.rb

--- a/build_config.rb
+++ b/build_config.rb
@@ -3,4 +3,5 @@ MRuby::Build.new do |conf|
   conf.gembox 'full-core'
   conf.gem File.expand_path(File.dirname(__FILE__))
   conf.enable_test
+  conf.cc.flags << "-DMRB_THREAD_COPY_VALUES"
 end

--- a/example/catch_signal.rb
+++ b/example/catch_signal.rb
@@ -1,14 +1,19 @@
 timer = TimerThread.new
 
-Signal.trap(:USR1) do |signo|
+SignalThread.trap(:USR1) do
   puts "catch signal from timer thread"
-  while !timer.running? do
-    puts "finish main thread"
-    exit 1
+
+  while timer.running? do
+    sleep 1
   end
+
+  puts "finish main thread"
+  exit 1
 end
 
 timer.run_with_signal 3000, :USR1
 
 puts "waiting timer"
-loop { sleep 1 }
+loop {
+  sleep 1
+}

--- a/example/catch_signal.rb
+++ b/example/catch_signal.rb
@@ -1,0 +1,14 @@
+timer = TimerThread.new
+
+Signal.trap(:USR1) do |signo|
+  puts "catch signal from timer thread"
+  while !timer.running? do
+    puts "finish main thread"
+    exit 1
+  end
+end
+
+timer.run_with_signal 3000, :USR1
+
+puts "waiting timer"
+loop { sleep 1 }

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,9 +3,9 @@ MRuby::Gem::Specification.new('mruby-timer') do |spec|
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.add_dependency 'mruby-thread'
   spec.add_dependency 'mruby-sleep'
-  spec.add_dependency 'mruby-signal'
+  spec.add_dependency 'mruby-signal-thread'
   spec.add_dependency 'mruby-process'
+
   spec.add_test_dependency 'mruby-sleep'
-  spec.add_test_dependency 'mruby-signal'
   spec.add_test_dependency 'mruby-process'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,5 @@
 MRuby::Gem::Specification.new('mruby-timer') do |spec|
+MRuby::Gem::Specification.new('mruby-timer-thread') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
   spec.add_dependency 'mruby-thread'

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,12 +1,10 @@
-MRuby::Gem::Specification.new('mruby-timer') do |spec|
 MRuby::Gem::Specification.new('mruby-timer-thread') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MATSUMOTO Ryosuke'
+  spec.cc.flags << "-DMRB_THREAD_COPY_VALUES"
   spec.add_dependency 'mruby-thread'
   spec.add_dependency 'mruby-sleep'
   spec.add_dependency 'mruby-signal-thread'
   spec.add_dependency 'mruby-process'
-
-  spec.add_test_dependency 'mruby-sleep'
-  spec.add_test_dependency 'mruby-process'
+  spec.add_test_dependency 'mruby-time'
 end

--- a/mrblib/mrb_timer_thread.rb
+++ b/mrblib/mrb_timer_thread.rb
@@ -24,7 +24,6 @@ class TimerThread
       while loop_time < timer * 1000
         loop_time += usleep interval
       end
-      trap sig, :SIG_DFL
       Process.kill sig, Process.pid
     end
   end

--- a/mrblib/mrb_timer_thread.rb
+++ b/mrblib/mrb_timer_thread.rb
@@ -16,6 +16,19 @@ class TimerThread
     end
   end
 
+  def run_with_signal msec_timer, signal
+    # thread attach another mrb_state, so need msec_timer arg
+    @timer_thread = Thread.new msec_timer, @timer_interval_usec, signal do |timer, interval, sig|
+      loop_time = 0
+      # calculate by usec
+      while loop_time < timer * 1000
+        loop_time += usleep interval
+      end
+      trap sig, :SIG_DFL
+      Process.kill sig, Process.pid
+    end
+  end
+
   def running?
     @timer_thread.alive?
   end

--- a/mrblib/mrb_timer_thread.rb
+++ b/mrblib/mrb_timer_thread.rb
@@ -5,26 +5,32 @@ class TimerThread
     @timer_interval_usec = 1000
   end
 
-  def run msec_timer
-    # thread attach another mrb_state, so need msec_timer arg
-    @timer_thread = Thread.new msec_timer, @timer_interval_usec do |timer, interval|
+  def timer_proc(timer)
+    Proc.new do
       loop_time = 0
       # calculate by usec
       while loop_time < timer * 1000
-        loop_time += usleep interval
+        loop_time += usleep @timer_interval_usec
       end
     end
   end
 
+  def run msec_timer
+    @timer_thread = Thread.new timer_proc(msec_timer) do |timer|
+      timer.call
+    end
+  end
+
   def run_with_signal msec_timer, signal
+    sigstr = signal.to_s
+    sig = Proc.new do
+      timer_proc(msec_timer).call
+      Process.kill sigstr, Process.pid
+    end
+
     # thread attach another mrb_state, so need msec_timer arg
-    @timer_thread = Thread.new msec_timer, @timer_interval_usec, signal do |timer, interval, sig|
-      loop_time = 0
-      # calculate by usec
-      while loop_time < timer * 1000
-        loop_time += usleep interval
-      end
-      Process.kill sig, Process.pid
+    @timer_thread = Thread.new sig do |signal_timer|
+      signal_timer.call
     end
   end
 

--- a/test/mrb_timer_thread.rb
+++ b/test/mrb_timer_thread.rb
@@ -19,3 +19,22 @@ assert("Timer#run") do
 
   assert_true (start - finish) < (timer_msec / 1000 + 2)
 end
+
+assert("Timer#run_with_signal") do
+  timer_msec = 5000
+  finish = 1
+
+  SignalThread.trap(:USR1) do
+    finish = Time.now
+  end
+
+  timer = TimerThread.new
+  start = Time.now
+
+  timer.run_with_signal timer_msec, :USR
+
+  while timer.running? do
+    sleep 1
+  end
+  assert_true (start - finish) < (timer_msec / 1000 + 2)
+end

--- a/test/mrb_timer_thread.rb
+++ b/test/mrb_timer_thread.rb
@@ -17,7 +17,7 @@ assert("Timer#run") do
 
   finish = Time.now
 
-  assert_true (start - finish) < (timer_msec / 1000 + 2)
+  assert_true (finish - start) > (timer_msec / 1000)
 end
 
 assert("Timer#run_with_signal") do

--- a/test/mrb_timer_thread.rb
+++ b/test/mrb_timer_thread.rb
@@ -28,12 +28,12 @@ assert("Timer#run_with_signal") do
     finish = Time.now
   end
 
-  timer = TimerThread.new
+  th = TimerThread.new
   start = Time.now
 
-  timer.run_with_signal timer_msec, :USR
+  th.run_with_signal timer_msec, :USR1
 
-  while timer.running? do
+  while th.running? do
     sleep 1
   end
   assert_true (start - finish) < (timer_msec / 1000 + 2)

--- a/test/mrb_timer_thread.rb
+++ b/test/mrb_timer_thread.rb
@@ -22,19 +22,18 @@ end
 
 assert("Timer#run_with_signal") do
   timer_msec = 5000
-  finish = 1
+  finish = nil
 
-  SignalThread.trap(:USR1) do
+  SignalThread.trap(:USR2) do
     finish = Time.now
   end
 
   th = TimerThread.new
   start = Time.now
-
-  th.run_with_signal timer_msec, :USR1
+  th.run_with_signal timer_msec, :USR2
 
   while th.running? do
     sleep 1
   end
-  assert_true (start - finish) < (timer_msec / 1000 + 2)
+  assert_true (finish - start) > (timer_msec / 1000)
 end

--- a/test/mrb_timer_thread.rb
+++ b/test/mrb_timer_thread.rb
@@ -13,7 +13,6 @@ assert("Timer#run") do
 
   while th.running? do
     sleep 1
-    puts "master thread sleeping loop"
   end
 
   finish = Time.now


### PR DESCRIPTION
current status

```
$ ./mruby/bin/mruby example/catch_signal.rb 
waiting timer
SignalException: SIGUSR1
Aborted (core dumped)
```