### PR TITLE
Support timer to a specific thread

### DIFF
--- a/src/timer_thread.c
+++ b/src/timer_thread.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <math.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -220,10 +221,16 @@ static int mrb_to_signo(mrb_state *mrb, mrb_value vsig)
   return sig;
 }
 
+struct mrb_timer_posix_thread_param {
+  int signo;
+  pthread_t tid;
+};
+
 typedef struct {
   timer_t *timer_ptr;
   int timer_signo;
   clock_t clockid;
+  struct mrb_timer_posix_thread_param *thread_param_ptr;
 } mrb_timer_posix_data;
 
 static void mrb_timer_posix_free(mrb_state *mrb, void *p)
@@ -231,6 +238,9 @@ static void mrb_timer_posix_free(mrb_state *mrb, void *p)
   mrb_timer_posix_data *data = (mrb_timer_posix_data *)p;
   timer_delete(*data->timer_ptr);
   mrb_free(mrb, data->timer_ptr);
+  if (data->thread_param_ptr) {
+    mrb_free(mrb, data->thread_param_ptr);
+  }
   mrb_free(mrb, data);
 }
 
@@ -250,8 +260,15 @@ static mrb_value mrb_rtsignal_get(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(SIGRTMIN + (int)idx);
 }
 
+static void mrb_timer_posix_thread_func(union sigval sv)
+{
+  struct mrb_timer_posix_thread_param *param = (struct mrb_timer_posix_thread_param *)(sv.sival_ptr);
+  pthread_kill(param->tid, param->signo);
+}
+
 #define MRB_TIMER_POSIX_KEY_SIGNO mrb_intern_lit(mrb, "signal")
 #define MRB_TIMER_POSIX_KEY_CLOCK_ID mrb_intern_lit(mrb, "clock_id")
+#define MRB_TIMER_POSIX_KEY_TID mrb_intern_lit(mrb, "tid")
 
 /* initialize */
 static mrb_value mrb_timer_posix_init(mrb_state *mrb, mrb_value self)
@@ -259,8 +276,10 @@ static mrb_value mrb_timer_posix_init(mrb_state *mrb, mrb_value self)
   mrb_timer_posix_data *data;
   timer_t *timer_ptr;
   mrb_value options = mrb_nil_value();
-  mrb_value has_signo_key, signo, clock_arg;
+  mrb_value has_signo_key, signo, clock_arg, tid_arg;
   clockid_t clockid = CLOCK_REALTIME;
+  pthread_t tid;
+  struct mrb_timer_posix_thread_param *param = NULL;
 
   struct sigevent sev;
   memset(&sev, 0, sizeof(struct sigevent));
@@ -294,6 +313,24 @@ static mrb_value mrb_timer_posix_init(mrb_state *mrb, mrb_value self)
     if (mrb_fixnum_p(clock_arg)) {
       clockid = (clockid_t)mrb_fixnum(clock_arg);
     }
+
+#ifdef SIGEV_THREAD_ID
+    tid_arg = mrb_hash_get(mrb, options, mrb_symbol_value(MRB_TIMER_POSIX_KEY_TID));
+    /* has key and is not nil */
+    if (mrb_float_p(tid_arg)) {
+      tid = (pthread_t)mrb_float(tid_arg);
+      param = mrb_malloc(mrb, sizeof(struct mrb_timer_posix_thread_param));
+      param->tid = tid;
+      param->signo = sev.sigev_signo;
+      if (param->signo == -1) { /* By default handling */
+        param->signo = SIGALRM;
+      }
+
+      sev.sigev_notify = SIGEV_THREAD;
+      sev.sigev_value.sival_ptr = (void *)param;
+      sev.sigev_notify_function = mrb_timer_posix_thread_func;
+    }
+#endif
   }
 
   data = (mrb_timer_posix_data *)DATA_PTR(self);
@@ -321,6 +358,9 @@ static mrb_value mrb_timer_posix_init(mrb_state *mrb, mrb_value self)
     data->timer_signo = sev.sigev_signo;
   }
   data->clockid = clockid;
+  if (param) {
+    data->thread_param_ptr = param;
+  }
 
   DATA_PTR(self) = data;
   return self;

--- a/src/timer_thread.c
+++ b/src/timer_thread.c
@@ -360,6 +360,8 @@ static mrb_value mrb_timer_posix_init(mrb_state *mrb, mrb_value self)
   data->clockid = clockid;
   if (param) {
     data->thread_param_ptr = param;
+  } else {
+    data->thread_param_ptr = NULL;
   }
 
   DATA_PTR(self) = data;

--- a/src/timer_thread.c
+++ b/src/timer_thread.c
@@ -314,7 +314,7 @@ static mrb_value mrb_timer_posix_init(mrb_state *mrb, mrb_value self)
       clockid = (clockid_t)mrb_fixnum(clock_arg);
     }
 
-#ifdef SIGEV_THREAD_ID
+#ifdef SIGEV_THREAD
     tid_arg = mrb_hash_get(mrb, options, mrb_symbol_value(MRB_TIMER_POSIX_KEY_TID));
     /* has key and is not nil */
     if (mrb_float_p(tid_arg)) {

--- a/test/posix_thread_test.rb
+++ b/test/posix_thread_test.rb
@@ -1,5 +1,4 @@
 assert("Timer::POSIX with RTSignal, interval timer and block") do
-  #def assert_equal(*a); p a; end
   timer_msec = 10
   sem = false
   v1 = 0

--- a/test/posix_thread_test.rb
+++ b/test/posix_thread_test.rb
@@ -1,0 +1,30 @@
+assert("Timer::POSIX with RTSignal, interval timer and block") do
+  #def assert_equal(*a); p a; end
+  timer_msec = 10
+  sem = false
+  v1 = 0
+  v2 = 0
+
+  t1 = SignalThread.trap(:RT5) { v1 += 1; sem = true }
+  t2 = SignalThread.trap(:RT5) { v2 += 1; sem = true }
+
+  begin
+    Timer::POSIX.new(tid: t2.tid, signal: :RT5).run(timer_msec)
+    until sem
+      usleep 1000 rescue nil
+    end
+    assert_equal 0, v1
+    assert_equal 1, v2
+    sem = false
+
+    Timer::POSIX.new(tid: t1.tid, signal: :RT5).run(timer_msec)
+    until sem
+      usleep 1000 rescue nil
+    end
+    assert_equal 1, v1
+    assert_equal 1, v2
+  rescue NotImplementedError => e
+    # In an unsupported platform (MacOS)
+    assert_equal "Unsupported platform", e.message
+  end
+end


### PR DESCRIPTION
Now we can register several hooks in the same signal.

Use cases are as tests written in [here](https://github.com/matsumotory/mruby-timer-thread/compare/support-timer-by-thread?expand=1#diff-f936515bc05f5dd1e76f918655124f81R1)